### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   semgrep:
     name: Scan
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/terraform-provider-openfga/security/code-scanning/1](https://github.com/openfga/terraform-provider-openfga/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since the job only checks out code and runs Semgrep, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the job level (under `semgrep:`), which will restrict the `GITHUB_TOKEN` to read-only access for this job. This change should be made directly under the job definition (after `name: Scan` and before `runs-on: ubuntu-latest`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
