### PR TITLE
fix: fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Main
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/terraform-provider-openfga/security/code-scanning/2](https://github.com/openfga/terraform-provider-openfga/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow. Since the workflow only calls another workflow (`test.yml`) via the `uses` keyword, and does not appear to require any write access itself, the safest minimal permissions are `contents: read`. This should be added at the root level of the workflow (before `on:`), so it applies to all jobs unless overridden. If the called workflow requires additional permissions, those should be set in that workflow. The change should be made in `.github/workflows/main.yml`, by inserting the following block after the `name:` line:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to specify repository content access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->